### PR TITLE
[FIX] Type Error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,7 @@ export const withAnchorPoint = (transform: TransformsStyle, anchorPoint: Point, 
         shiftTranslateX.push({
             translateX: size.width * (anchorPoint.x - defaultAnchorPoint.x),
         });
-        injectedTransform = shiftTranslateX.concat(injectedTransform);
+        injectedTransform = [...shiftTranslateX, ...injectedTransform];
         // shift after rotation
         injectedTransform.push({
             translateX: size.width * (defaultAnchorPoint.x - anchorPoint.x),
@@ -94,7 +94,7 @@ export const withAnchorPoint = (transform: TransformsStyle, anchorPoint: Point, 
         shiftTranslateY.push({
             translateY: size.height * (anchorPoint.y - defaultAnchorPoint.y),
         });
-        injectedTransform = shiftTranslateY.concat(injectedTransform);
+        injectedTransform = [...shiftTranslateY, ...injectedTransform];
         // shift after rotation
         injectedTransform.push({
             translateY: size.height * (defaultAnchorPoint.y - anchorPoint.y),


### PR DESCRIPTION
This is to fix tslint error
```
No overload matches this call.

Overload 1 of 2, '(...items: ConcatArray<PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 6 more ... | SkewYTransform>[]): (PerpectiveTransform | ... 10 more ... | SkewYTransform)[]', gave the following error.
    Argument of type '(PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 7 more ... | MatrixTransform)[]' is not assignable to parameter of type 'ConcatArray<PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 6 more ... | SkewYTransform>'.
      The types returned by 'slice(...)' are incompatible between these types.
        Type '(PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 7 more ... | MatrixTransform)[]' is not assignable to type '(PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 6 more ... | SkewYTransform)[]'.
          Type 'PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 7 more ... | MatrixTransform' is not assignable to type 'PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 6 more ... | SkewYTransform'.
            Type 'MatrixTransform' is not assignable to type 'PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 6 more ... | SkewYTransform'.
              Property 'skewY' is missing in type 'MatrixTransform' but required in type 'SkewYTransform'.
  Overload 2 of 2, '(...items: (PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 7 more ... | ConcatArray<...>)[]): (PerpectiveTransform | ... 10 more ... | SkewYTransform)[]', gave the following error.
    Argument of type '(PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 7 more ... | MatrixTransform)[]' is not assignable to parameter of type 'PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 7 more ... | ConcatArray<...>'.
      Type '(PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 7 more ... | MatrixTransform)[]' is not assignable to type 'ConcatArray<PerpectiveTransform | RotateTransform | RotateXTransform | RotateYTransform | RotateZTransform | ... 6 more ... | SkewYTransform>'.

67         injectedTransform = shiftTranslateX.concat(injectedTransform);
```