### PR TITLE
[FIX] Parameter 'transform' implicitly has an 'any' type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+import { TransformsStyle } from "react-native";
+
 export interface Point {
     x: number;
     y: number;
@@ -22,7 +24,7 @@ const isValidSize = (size: Size): boolean => {
 
 const defaultAnchorPoint = { x: 0.5, y: 0.5 };
 
-export const withAnchorPoint = (transform, anchorPoint: Point, size: Size) => {
+export const withAnchorPoint = (transform: TransformsStyle, anchorPoint: Point, size: Size) => {
     if (!isValidPoint(anchorPoint)) {
         return transform;
     }


### PR DESCRIPTION
An error occurred on `tsc --noEmit` command.

```
$ tsc --noEmit && eslint --ext .js,.jsx,.ts,.tsx ./
node_modules/react-native-anchor-point/index.ts:27:33 - error TS7006: Parameter 'transform' implicitly has an 'any' type.

27 export const withAnchorPoint = (transform, anchorPoint: Point, size: Size) => {
                                   ~~~~~~~~~


Found 1 error.
```