### PR TITLE
Fix importsNotUsedAsValues ts error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { TransformsStyle } from "react-native";
+import type { TransformsStyle } from "react-native";
 
 export interface Point {
     x: number;


### PR DESCRIPTION
Error:
```
node_modules/react-native-anchor-point/index.ts:1:1 - error TS1371: This import is never used 
as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
```