### PR TITLE
removed pointless point validation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,14 +10,6 @@ export interface Size {
     height: number;
 }
 
-const isValidPoint = (point: Point): boolean => {
-    return isValidPointValue(point.x) && isValidPointValue(point.y);
-};
-
-const isValidPointValue = (value: number): boolean => {
-    return value >= 0 && value <= 1.0;
-};
-
 const isValidSize = (size: Size): boolean => {
     return size && size.width > 0 && size.height > 0;
 }; 
@@ -25,10 +17,6 @@ const isValidSize = (size: Size): boolean => {
 const defaultAnchorPoint = { x: 0.5, y: 0.5 };
 
 export const withAnchorPoint = (transform: TransformsStyle, anchorPoint: Point, size: Size) => {
-    if (!isValidPoint(anchorPoint)) {
-        return transform;
-    }
-
     if(!isValidSize(size)) {
         return transform;
     }


### PR DESCRIPTION
For my project, I would like to have a transformation center point outside the area of the view. I think that's useful for many other use cases as well, so I simply deleted the `isValidPoint`check.