### PR TITLE
Update type signatures for RN 0.71.9

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { TransformsStyle } from "react-native";
+import type { TransformsStyle, Animated } from "react-native";
 
 export interface Point {
     x: number;
@@ -12,11 +12,14 @@ export interface Size {
 
 const isValidSize = (size: Size): boolean => {
     return size && size.width > 0 && size.height > 0;
-}; 
+};
 
 const defaultAnchorPoint = { x: 0.5, y: 0.5 };
 
-export const withAnchorPoint = (transform: TransformsStyle, anchorPoint: Point, size: Size) => {
+export const withAnchorPoint = (
+    transform: TransformsStyle | Animated.WithAnimatedValue<TransformsStyle>,
+    anchorPoint: Point, size: Size
+) => {
     if(!isValidSize(size)) {
         return transform;
     }
@@ -33,11 +36,14 @@ export const withAnchorPoint = (transform: TransformsStyle, anchorPoint: Point, 
         shiftTranslateX.push({
             translateX: size.width * (anchorPoint.x - defaultAnchorPoint.x),
         });
-        injectedTransform = [...shiftTranslateX, ...injectedTransform];
-        // shift after rotation
-        injectedTransform.push({
-            translateX: size.width * (defaultAnchorPoint.x - anchorPoint.x),
-        });
+
+        if (Array.isArray(injectedTransform)) {
+            injectedTransform = [...shiftTranslateX, ...injectedTransform];
+            // shift after rotation
+            injectedTransform.push({
+                translateX: size.width * (defaultAnchorPoint.x - anchorPoint.x),
+            });
+        }
     }
 
     if (!Array.isArray(injectedTransform)) {


### PR DESCRIPTION
This is the patch in https://github.com/sueLan/react-native-anchor-point/issues/15 as a pull request

There has been a change in React Native 0.71.9 that changes the way transforms work, allowing string transform styles.

For now, I've excluded the type from the transform arguments to the `withAnchorPoint` hook, and added a guard around the transform being an array.